### PR TITLE
Fixes to compile cleanly on recent clang/gcc

### DIFF
--- a/SConscript.py
+++ b/SConscript.py
@@ -46,7 +46,7 @@ cc = 'clang'
 cxx = 'clang++'
 
 if use_gcc:
-    cc = 'gcc-4.8'
+    cc = 'gcc'
     cxx = 'g++'
 
 env = Environment(

--- a/src/c/data_structures/sorted_list_set.h
+++ b/src/c/data_structures/sorted_list_set.h
@@ -3,6 +3,7 @@
 
 #include <limits.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/c/locks/ccsynch_lock.h
+++ b/src/c/locks/ccsynch_lock.h
@@ -20,13 +20,13 @@
 typedef struct {
     volatile atomic_uintptr_t next;
     void (*requestFunction)(unsigned int, void *);
+    volatile atomic_int wait;
     unsigned int messageSize;
     unsigned char * buffer;
     bool completed;
-    volatile atomic_int wait;
     char pad2[CACHE_LINE_SIZE_PAD(sizeof(void *)*2 + 
                                   sizeof(unsigned int) +
-                                  CCSYNCH_BUFFER_SIZE +
+                                  sizeof(char *) +
                                   sizeof(bool) +
                                   sizeof(atomic_int))];
     unsigned char tempBuffer[CACHE_LINE_SIZE*8]; //used in ccsynch_delegate_or_lock 

--- a/src/c/locks/oo_lock_interface.h
+++ b/src/c/locks/oo_lock_interface.h
@@ -2,6 +2,7 @@
 #define OO_LOCK_INTERFACE_H
 
 #include <stdbool.h>
+#include <stdlib.h>
 #include "misc/padded_types.h"
 
 typedef struct {

--- a/src/c/tests/test_lock.c
+++ b/src/c/tests/test_lock.c
@@ -155,7 +155,9 @@ int test_mutual_exclusion(double delegatePercentageParm,
         pthread_t threads[i];
         LLPaddedLocalCounter localInCSCounters[i];
         LLPaddedSeed localSeeds[i];
-        ThreadLocalData * threadLocalData = aligned_alloc(CACHE_LINE_SIZE, sizeof(ThreadLocalData) * i);
+        size_t allocSize = sizeof(ThreadLocalData) * i;
+        allocSize += CACHE_LINE_SIZE_PAD(allocSize);
+        ThreadLocalData * threadLocalData = aligned_alloc(CACHE_LINE_SIZE, allocSize);
         for(int n = 0; n < i; n++){
             localInCSCounters[n].value = 0;
             localSeeds[n].value = n;


### PR DESCRIPTION
With these changes, the library builds cleanly and all tests pass using clang and gcc on recent FreeBSD, Linux, and macOS. Thank you for this library!